### PR TITLE
modify preRequest retryHandle data.errcode to data.code

### DIFF
--- a/lib/api_common.js
+++ b/lib/api_common.js
@@ -172,7 +172,7 @@ API.prototype.preRequest = function (method, args, retryed) {
       if (!retryed) {
         var retryHandle = function (err, data, res) {
           // 42001 重试
-          if (data && data.errcode && data.errcode === 42001) {
+          if (data && data.code && data.code === 42001) {
             return that.preRequest(method, args, true);
           }
           callback(err, data, res);


### PR DESCRIPTION
微信的返回参数已经变了，不再是errcode，那个会报错，现在错误返回是{name:'.......',code:42001}，希望修改一下，谢谢！